### PR TITLE
Fix Python 3.13 dependency resolution for design tool

### DIFF
--- a/design-tool/README.md
+++ b/design-tool/README.md
@@ -7,7 +7,9 @@ A GUI tool for designing logarithmic-spiral soft robots (2‑cable / 3‑cable),
 - Commercial use requires a separate license.
 
 ## Requirements
-- Python 3.10+ (recommended)
+- Python 3.10+ 
+- Tested on Python 3.10 and 3.11
+- Python 3.13 requires the newer `vtk` wheel selected by `requirements.txt`
 - See `requirements.txt`
 
 Install dependencies:

--- a/design-tool/requirements.txt
+++ b/design-tool/requirements.txt
@@ -1,6 +1,7 @@
 PySide6==6.10.1
 mujoco
 matplotlib==3.10.8
-vtk==9.3.1
+vtk==9.3.1; python_version < "3.13"
+vtk==9.6.1; python_version >= "3.13"
 cadquery==2.6.1
 numpy==2.4.2


### PR DESCRIPTION
## Summary
- make `design-tool/requirements.txt` select `vtk==9.3.1` for Python < 3.13
- use `vtk==9.6.1` for Python 3.13+ where cp313 wheels exist
- clarify tested Python versions and the Python 3.13 note in the design tool README

## Context
- `vtk==9.3.1` does not provide a Python 3.13 wheel on PyPI
- Python 3.11 remains on the existing `vtk==9.3.1` pin