### PR TITLE
Fix VTK repaint loop on macOS

### DIFF
--- a/design-tool/DesignTool.py
+++ b/design-tool/DesignTool.py
@@ -422,6 +422,10 @@ class MainWindow(QMainWindow):
             self.vtk_widget = QVTKOpenGLNativeWidget()
         else:
             self.vtk_widget = QVTKRenderWindowInteractor()
+        if sys.platform == "darwin":
+            # Qt 6.10 on macOS otherwise retriggers paintEvent from each VTK
+            # render, causing an infinite render/repaint loop.
+            self.vtk_widget.setAttribute(Qt.WA_PaintOnScreen, False)
         self.vtk_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.vtk_widget.setMinimumSize(240, 200)
         self.vtk_placeholder = QLabel("3D Preview (placeholder)")
@@ -2221,7 +2225,6 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-
 
 
 


### PR DESCRIPTION
## Summary

Fix the GUI startup hang on macOS when using PySide6 6.10.1 with VTK's `QVTKRenderWindowInteractor`.

## Problem

On macOS, launching `DesignTool.py` could leave only a Python icon in the Dock while no GUI appeared. The process remained alive and continuously consumed memory.

The VTK widget enables `Qt.WA_PaintOnScreen`. With Qt 6.10 on macOS, each VTK render can trigger another Qt `paintEvent`, creating an infinite loop:

`paintEvent → VTK Render → OpenGL flush → paintEvent`

This is consistent with the upstream VTK report:
https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12956

## Fix

Disable `Qt.WA_PaintOnScreen` for the VTK widget on macOS:

```python
if sys.platform == "darwin":
    self.vtk_widget.setAttribute(Qt.WA_PaintOnScreen, False)